### PR TITLE
Set the right processors for the mega2560 boards.

### DIFF
--- a/Grbl9eMega2560/Makefile
+++ b/Grbl9eMega2560/Makefile
@@ -28,7 +28,7 @@
 #                is connected.
 # FUSES ........ Parameters for avrdude to flash the fuses appropriately.
 
-DEVICE     ?= atmega328p
+DEVICE     ?= atmega2560
 CLOCK      = 16000000
 PROGRAMMER ?= -c avrisp2 -P usb
 OBJECTS    = main.o motion_control.o gcode.o spindle_control.o coolant_control.o serial.o \

--- a/Grbl9fMega2560/Makefile
+++ b/Grbl9fMega2560/Makefile
@@ -28,7 +28,7 @@
 #                is connected.
 # FUSES ........ Parameters for avrdude to flash the fuses appropriately.
 
-DEVICE     ?= atmega328p
+DEVICE     ?= atmega2560
 CLOCK      = 16000000
 PROGRAMMER ?= -c avrisp2 -P usb
 OBJECTS    = main.o motion_control.o gcode.o spindle_control.o coolant_control.o serial.o \


### PR DESCRIPTION
This fixes the processor names in the mega2560 directories.
